### PR TITLE
Release v0.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.5.10 - 2026-04-27
+
+### Fixed
+
+- Fixed iOS Microsoft sign-in so `ASWebAuthenticationSession` is retained until callback or cancellation and duplicate sessions fail with `operation_in_progress`.
+- Fixed the example app header so it displays the current package version.
+
+### Verified
+
+- `bun run check:ci`
+- `bunx expo install --check --cwd apps/example`
+- `bunx expo-doctor@latest apps/example`
+- `bun run example:prebuild`
+- `bun run publish-package:dry-run`
+
 ## 0.5.9 - 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-native-nitro-auth
 
-![npm](https://img.shields.io/badge/npm-v0.5.9-f97316?style=flat-square)
+![npm](https://img.shields.io/badge/npm-v0.5.10-f97316?style=flat-square)
 ![license](https://img.shields.io/badge/license-MIT-007ec6?style=flat-square)
 ![react-native](https://img.shields.io/badge/react--native-%3E%3D0.75-61dafb?style=flat-square)
 ![nitro-modules](https://img.shields.io/badge/nitro--modules-%3E%3D0.35.0-black?style=flat-square)

--- a/apps/example/components/FeatureDemo.tsx
+++ b/apps/example/components/FeatureDemo.tsx
@@ -27,7 +27,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { SmokeTestCard } from "./SmokeTestCard";
 
-const PACKAGE_VERSION = "0.5.8";
+const PACKAGE_VERSION = "0.5.10";
 const CALENDAR_SCOPE = "https://www.googleapis.com/auth/calendar.readonly";
 
 const PROVIDERS: readonly {

--- a/bun.lock
+++ b/bun.lock
@@ -52,7 +52,7 @@
     },
     "packages/react-native-nitro-auth": {
       "name": "react-native-nitro-auth",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "devDependencies": {
         "@expo/config-plugins": "^55.0.8",
         "@react-native/babel-preset": "^0.83.6",

--- a/packages/react-native-nitro-auth/CHANGELOG.md
+++ b/packages/react-native-nitro-auth/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.5.10 - 2026-04-27
+
+### Fixed
+
+- Fixed iOS Microsoft sign-in so `ASWebAuthenticationSession` is retained until callback or cancellation and duplicate sessions fail with `operation_in_progress`.
+- Fixed the example app header so it displays the current package version.
+
+### Verified
+
+- `bun run check:ci`
+- `bunx expo install --check --cwd apps/example`
+- `bunx expo-doctor@latest apps/example`
+- `bun run example:prebuild`
+- `bun run publish-package:dry-run`
+
 ## 0.5.9 - 2026-04-24
 
 ### Added

--- a/packages/react-native-nitro-auth/README.md
+++ b/packages/react-native-nitro-auth/README.md
@@ -1,6 +1,6 @@
 # react-native-nitro-auth
 
-![npm](https://img.shields.io/badge/npm-v0.5.9-f97316?style=flat-square)
+![npm](https://img.shields.io/badge/npm-v0.5.10-f97316?style=flat-square)
 ![license](https://img.shields.io/badge/license-MIT-007ec6?style=flat-square)
 ![react-native](https://img.shields.io/badge/react--native-%3E%3D0.75-61dafb?style=flat-square)
 ![nitro-modules](https://img.shields.io/badge/nitro--modules-%3E%3D0.35.0-black?style=flat-square)

--- a/packages/react-native-nitro-auth/ios/AuthAdapter.swift
+++ b/packages/react-native-nitro-auth/ios/AuthAdapter.swift
@@ -10,6 +10,7 @@ public class AuthAdapter: NSObject {
   private static var inMemoryMicrosoftRefreshToken: String?
   private static var inMemoryMicrosoftScopes: [String] = defaultMicrosoftScopes
   private static var inMemoryGoogleServerAuthCode: String?
+  private static var activeMicrosoftWebAuthSession: ASWebAuthenticationSession?
   private static let tokenStoreLock = NSLock()
 
   @objc
@@ -135,22 +136,32 @@ public class AuthAdapter: NSObject {
     let callbackScheme = "msauth.\(bundleId)"
     
     DispatchQueue.main.async {
+      guard self.activeMicrosoftWebAuthSession == nil else {
+        completion(nil, "operation_in_progress")
+        return
+      }
+
+      let completeAndClearSession = { (data: NSDictionary?, error: String?) in
+        self.activeMicrosoftWebAuthSession = nil
+        completion(data, error)
+      }
+
       let session = ASWebAuthenticationSession(url: authUrl, callbackURLScheme: callbackScheme) { callbackURL, error in
         if let error = error {
           let nsError = error as NSError
           if nsError.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
-            completion(nil, "cancelled")
+            completeAndClearSession(nil, "cancelled")
           } else if nsError.domain.lowercased().contains("network") || nsError.code == NSURLErrorNotConnectedToInternet {
-            completion(nil, "network_error")
+            completeAndClearSession(nil, "network_error")
           } else {
-            completion(nil, "unknown")
+            completeAndClearSession(nil, "unknown")
           }
           return
         }
 
         guard let callbackURL = callbackURL,
               let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false) else {
-          completion(nil, "unknown")
+          completeAndClearSession(nil, "unknown")
           return
         }
 
@@ -163,20 +174,21 @@ public class AuthAdapter: NSObject {
           // OAuth error codes are already structured (e.g. "access_denied").
           // Map well-known ones; fall back to "unknown".
           let mapped = mapOAuthError(errorCode)
-          completion(nil, mapped)
+          completeAndClearSession(nil, mapped)
           return
         }
 
         guard let returnedState = params["state"], returnedState == state else {
-          completion(nil, "invalid_state")
+          completeAndClearSession(nil, "invalid_state")
           return
         }
 
         guard let code = params["code"] else {
-          completion(nil, "unknown")
+          completeAndClearSession(nil, "unknown")
           return
         }
         
+        self.activeMicrosoftWebAuthSession = nil
         exchangeCodeForTokens(
           code: code,
           codeVerifier: codeVerifier,
@@ -191,14 +203,17 @@ public class AuthAdapter: NSObject {
       }
 
       guard let window = activeWindow() else {
-        completion(nil, "no_window")
+        completeAndClearSession(nil, "no_window")
         return
       }
       let contextProvider = WebAuthContextProvider(anchor: window)
       session.presentationContextProvider = contextProvider
       objc_setAssociatedObject(session, &contextProviderHandle, contextProvider, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
       session.prefersEphemeralWebBrowserSession = false
-      session.start()
+      self.activeMicrosoftWebAuthSession = session
+      if !session.start() {
+        completeAndClearSession(nil, "unknown")
+      }
     }
   }
   
@@ -685,6 +700,10 @@ public class AuthAdapter: NSObject {
   @objc
   public static func logout() {
     GIDSignIn.sharedInstance.signOut()
+    DispatchQueue.main.async {
+      self.activeMicrosoftWebAuthSession?.cancel()
+      self.activeMicrosoftWebAuthSession = nil
+    }
     tokenStoreLock.lock()
     inMemoryMicrosoftRefreshToken = nil
     inMemoryMicrosoftScopes = defaultMicrosoftScopes

--- a/packages/react-native-nitro-auth/package.json
+++ b/packages/react-native-nitro-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-auth",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "High-performance authentication library for React Native with Google Sign-In, Apple Sign-In, and Microsoft Sign-In support, powered by Nitro Modules (JSI)",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",


### PR DESCRIPTION
## Summary
- Retain the active iOS Microsoft `ASWebAuthenticationSession` until callback, cancellation, or start failure.
- Guard duplicate iOS Microsoft auth sessions with `operation_in_progress`.
- Prepare unpublished `react-native-nitro-auth@0.5.10` release metadata, changelog, README badges, example version display, and Bun lockfile metadata.

## Verification
- `bun run publish-package:dry-run`
- Dry publish confirmed `react-native-nitro-auth@0.5.10` is unpublished and publishable.
- Pack dry run included 172 files, 0.55MB unpacked.

## Notes
- No npm publish, tag, or GitHub release was created.
- `example:android` and `example:ios` were not run in this PR prep pass; they still need a manual device/simulator sign-in check before publishing.