### PR TITLE
fix: harden npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,7 @@ name: Publish npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 env:
   BUN_VERSION: "1.3.10"
@@ -35,8 +36,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang llvm
 
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+      - name: Install npm for trusted publishing
+        run: |
+          bun install -g npm@latest
+          NPM_BIN="$(bun pm bin -g)"
+          printf '%s\n' "$NPM_BIN" >> "$GITHUB_PATH"
+          "$NPM_BIN/npm" --version
 
       - uses: actions/cache@v5
         with:
@@ -49,6 +54,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Verify release tag
+        if: github.event_name == 'release'
         run: |
           PACKAGE_VERSION="$(node -p "require('./${PACKAGE_DIR}/package.json').version")"
           RELEASE_TAG="${GITHUB_REF_NAME#v}"
@@ -62,6 +68,7 @@ jobs:
         run: bun scripts/publish.js --dry-run --skip-git-check
 
       - name: Resolve npm dist tag
+        if: github.event_name == 'release'
         id: dist-tag
         run: |
           PACKAGE_VERSION="$(node -p "require('./${PACKAGE_DIR}/package.json').version")"
@@ -72,5 +79,6 @@ jobs:
           fi
 
       - name: Publish to npm
+        if: github.event_name == 'release'
         working-directory: ${{ env.PACKAGE_DIR }}
         run: npm publish --access public --tag "${{ steps.dist-tag.outputs.tag }}" --ignore-scripts

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -65,6 +65,8 @@ jobs:
           fi
 
       - name: Validate publish package
+        env:
+          NITRO_AUTH_DRY_RUN_PUBLISHER: npm
         run: bun scripts/publish.js --dry-run --skip-git-check
 
       - name: Resolve npm dist tag

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -28,6 +28,7 @@ const skipExpoDoctor = hasFlag("--skip-expo-doctor");
 const quick = hasFlag("--quick");
 const tag = getArgValue("--tag") || "latest";
 const otp = getArgValue("--otp");
+const dryRunPublisher = process.env.NITRO_AUTH_DRY_RUN_PUBLISHER || "bun";
 
 function hasFlag(name) {
   return args.includes(name);
@@ -166,6 +167,13 @@ function buildPublishArgs() {
   return publishArgs;
 }
 
+function buildPublishCommand(publishArgs) {
+  const publishBin =
+    dryRun && dryRunPublisher === "npm" ? "npm publish" : "bun publish";
+
+  return `${publishBin} ${publishArgs.join(" ")}`;
+}
+
 function getReleaseSteps() {
   const steps = [
     [
@@ -261,7 +269,7 @@ async function main() {
   }
 
   log(dryRun ? "Running publish dry run..." : "Publishing to npm...", "cyan");
-  must(`bun publish ${publishArgs.join(" ")}`, {
+  must(buildPublishCommand(publishArgs), {
     cwd: packageDir,
     label: dryRun ? "Publish dry run" : "Publish package",
   });


### PR DESCRIPTION
## Summary
Fixes the release publish workflow after the `v0.5.11` run failed before validation.

## Changes
- Add manual dry-run dispatch for the npm publish workflow.
- Install npm through Bun instead of self-upgrading the runner npm.
- Keep release tag validation and real publish steps release-only.
- Use npm for CI publish dry runs so branch dispatch can validate packaging without Bun auth.

## Test
- `bunx actionlint .github/workflows/npm-publish.yml`
- `git diff --check`
- `NITRO_AUTH_DRY_RUN_PUBLISHER=npm bun scripts/publish.js --dry-run --skip-git-check --skip-checks --skip-expo-doctor`
- `workflow_dispatch` on `fix-npm-publish-workflow`: https://github.com/JoaoPauloCMarra/react-native-nitro-auth/actions/runs/25408289985