### PR TITLE
Ship Watchman ignore for Android CMake cache

### DIFF
--- a/packages/react-native-nitro-auth/.watchmanconfig
+++ b/packages/react-native-nitro-auth/.watchmanconfig
@@ -1,0 +1,6 @@
+{
+  "ignore_dirs": [
+    "android/.cxx",
+    "android/build"
+  ]
+}

--- a/packages/react-native-nitro-auth/package.json
+++ b/packages/react-native-nitro-auth/package.json
@@ -20,6 +20,7 @@
     "CHANGELOG.md",
     "*.podspec",
     "app.plugin.js",
+    ".watchmanconfig",
     "!**/__tests__",
     "!**/__fixtures__",
     "!**/__mocks__",


### PR DESCRIPTION
# Summary
Ships a package-local Watchman config so consumers that watch the installed package do not scan transient Android CMake output.

# Changes
- Add `.watchmanconfig` for Android `.cxx` and build output
- Include the config in the published package files