### PR TITLE
Release v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.5 - 2026-06-11
+
+### Fixed
+
+- Moved the Expo iOS Google Sign-In CocoaPods modular-header setup into the package config plugin so Expo/CNG consumers no longer need app-level `AppCheckCore`, `GoogleUtilities`, or `RecaptchaInterop` pod workarounds.
+- Added the package plugin dependency needed to apply the iOS build-properties setup from the package.
+
 ## 0.6.4 - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ Plugin options:
 Web reads provider client IDs from `expo.extra`; native platforms read values
 written by the plugin during prebuild.
 
+On iOS, the plugin also applies the CocoaPods modular-header settings required
+by the Google Sign-In dependency chain (`AppCheckCore`, `GoogleUtilities`, and
+`RecaptchaInterop`). Expo apps should not add those pods manually through
+`expo-build-properties`.
+
 Microsoft tenant values are validated before opening the authorization URL. Use
 `common`, `organizations`, `consumers`, a tenant ID, or a tenant domain for
 standard Entra ID. For B2C, set `microsoftB2cDomain` to a hostname such as

--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,10 @@
     },
     "packages/react-native-nitro-auth": {
       "name": "react-native-nitro-auth",
-      "version": "0.6.3",
+      "version": "0.6.4",
+      "dependencies": {
+        "expo-build-properties": "~56.0.18",
+      },
       "devDependencies": {
         "@expo/config-plugins": "^56.0.8",
         "@react-native/babel-preset": "^0.85.3",

--- a/packages/react-native-nitro-auth/CHANGELOG.md
+++ b/packages/react-native-nitro-auth/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.5 - 2026-06-11
+
+### Fixed
+
+- Moved the Expo iOS Google Sign-In CocoaPods modular-header setup into the package config plugin so Expo/CNG consumers no longer need app-level `AppCheckCore`, `GoogleUtilities`, or `RecaptchaInterop` pod workarounds.
+- Added the package plugin dependency needed to apply the iOS build-properties setup from the package.
+
 ## 0.6.4 - 2026-06-11
 
 ### Added

--- a/packages/react-native-nitro-auth/README.md
+++ b/packages/react-native-nitro-auth/README.md
@@ -106,6 +106,11 @@ Plugin options:
 Web reads provider client IDs from `expo.extra`; native platforms read values
 written by the plugin during prebuild.
 
+On iOS, the plugin also applies the CocoaPods modular-header settings required
+by the Google Sign-In dependency chain (`AppCheckCore`, `GoogleUtilities`, and
+`RecaptchaInterop`). Expo apps should not add those pods manually through
+`expo-build-properties`.
+
 Microsoft tenant values are validated before opening the authorization URL. Use
 `common`, `organizations`, `consumers`, a tenant ID, or a tenant domain for
 standard Entra ID. For B2C, set `microsoftB2cDomain` to a hostname such as

--- a/packages/react-native-nitro-auth/app.plugin.js
+++ b/packages/react-native-nitro-auth/app.plugin.js
@@ -1,3 +1,4 @@
+const { withBuildProperties } = require("expo-build-properties");
 const {
   withInfoPlist,
   withEntitlementsPlist,
@@ -8,10 +9,34 @@ const {
 } = require("@expo/config-plugins");
 const pkg = require("./package.json");
 
+const googleSignInIosPods = [
+  { name: "AppCheckCore", modular_headers: true },
+  { name: "GoogleUtilities", modular_headers: true },
+  { name: "RecaptchaInterop", modular_headers: true },
+];
+
+function getNitroAuthIosExtraPods(extraPods = []) {
+  const pods = Array.isArray(extraPods) ? [...extraPods] : [];
+  const existingPodNames = new Set(pods.map((pod) => pod?.name));
+
+  for (const pod of googleSignInIosPods) {
+    if (!existingPodNames.has(pod.name)) {
+      pods.push(pod);
+    }
+  }
+
+  return pods;
+}
+
 const withNitroAuth = (config, props = {}) => {
   const { ios = {}, android = {} } = props;
 
-  // 1. iOS Info.plist
+  config = withBuildProperties(config, {
+    ios: {
+      extraPods: getNitroAuthIosExtraPods(config.ios?.extraPods),
+    },
+  });
+
   config = withInfoPlist(config, (config) => {
     if (ios.googleClientId) {
       config.modResults.GIDClientID = ios.googleClientId;
@@ -34,10 +59,8 @@ const withNitroAuth = (config, props = {}) => {
         ];
       }
     }
-    // Microsoft configuration
     if (ios.microsoftClientId) {
       config.modResults.MSALClientID = ios.microsoftClientId;
-      // Add MSAL redirect URL scheme
       const msalScheme = `msauth.${config.ios?.bundleIdentifier}`;
       const existingSchemes = config.modResults.CFBundleURLTypes || [];
       if (
@@ -62,7 +85,6 @@ const withNitroAuth = (config, props = {}) => {
     return config;
   });
 
-  // 2. iOS Entitlements
   if (ios.appleSignIn === true) {
     config = withEntitlementsPlist(config, (config) => {
       config.modResults["com.apple.developer.applesignin"] = ["Default"];
@@ -70,7 +92,6 @@ const withNitroAuth = (config, props = {}) => {
     });
   }
 
-  // 3. Android Strings (for Google and Microsoft Client IDs)
   config = withStringsXml(config, (config) => {
     if (android.googleClientId) {
       config.modResults = AndroidConfig.Strings.setStringItem(
@@ -119,7 +140,6 @@ const withNitroAuth = (config, props = {}) => {
     return config;
   });
 
-  // 4. Android Manifest for MSAL redirect
   if (android.microsoftClientId) {
     config = withAndroidManifest(config, (config) => {
       const manifest = config.modResults.manifest;
@@ -170,3 +190,8 @@ const withNitroAuth = (config, props = {}) => {
 };
 
 module.exports = createRunOncePlugin(withNitroAuth, pkg.name, pkg.version);
+module.exports.withNitroAuth = withNitroAuth;
+module.exports._internal = {
+  getNitroAuthIosExtraPods,
+  googleSignInIosPods,
+};

--- a/packages/react-native-nitro-auth/package.json
+++ b/packages/react-native-nitro-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-auth",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "High-performance authentication library for React Native with Google Sign-In, Apple Sign-In, and Microsoft Sign-In support, powered by Nitro Modules (JSI)",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -82,6 +82,9 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"
+  },
+  "dependencies": {
+    "expo-build-properties": "~56.0.18"
   },
   "devDependencies": {
     "@expo/config-plugins": "^56.0.8",

--- a/packages/react-native-nitro-auth/src/__tests__/app-plugin.test.js
+++ b/packages/react-native-nitro-auth/src/__tests__/app-plugin.test.js
@@ -1,0 +1,25 @@
+const { _internal } = require("../../app.plugin.js");
+
+describe("Expo config plugin", () => {
+  it("adds modular header pods for the GoogleSignIn dependency chain", () => {
+    expect(_internal.getNitroAuthIosExtraPods()).toEqual([
+      { name: "AppCheckCore", modular_headers: true },
+      { name: "GoogleUtilities", modular_headers: true },
+      { name: "RecaptchaInterop", modular_headers: true },
+    ]);
+  });
+
+  it("preserves existing pods and does not duplicate managed pods", () => {
+    const extraPods = [
+      { name: "ExistingPod", version: "1.0.0" },
+      { name: "GoogleUtilities", modular_headers: true },
+    ];
+
+    expect(_internal.getNitroAuthIosExtraPods(extraPods)).toEqual([
+      { name: "ExistingPod", version: "1.0.0" },
+      { name: "GoogleUtilities", modular_headers: true },
+      { name: "AppCheckCore", modular_headers: true },
+      { name: "RecaptchaInterop", modular_headers: true },
+    ]);
+  });
+});


### PR DESCRIPTION
# Changes
- Move Google Sign-In iOS modular-header CocoaPods setup into the Expo config plugin.
- Add the package plugin dependency needed for the iOS build-properties update.
- Document package-owned iOS setup and keep packaged README/CHANGELOG in sync.
- Add plugin coverage for preserving existing extra pods without duplicates.
