### PR TITLE
Auth 0.8.0: loginAndGetUser and derived Google URL scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.8.0 - 2026-08-13
+
+### Breaking changes
+
+- None.
+
+### Added
+
+- `AuthService.loginAndGetUser()` runs the existing `login()` native call and
+  returns `currentUser`, or rejects with `not_signed_in` when login succeeds
+  without a session. `login()` remains `Promise<void>`.
+- The Expo plugin derives `ios.googleUrlScheme` from `ios.googleClientId` when
+  the scheme is omitted. An explicit `ios.googleUrlScheme` still wins.
+
+### Changed
+
+- Documented that `logout()` is synchronous `void`.
+
 ## 0.7.0 - 2026-08-12
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ export default {
           ios: {
             googleClientId: process.env.GOOGLE_IOS_CLIENT_ID,
             googleServerClientId: process.env.GOOGLE_SERVER_CLIENT_ID,
-            googleUrlScheme: process.env.GOOGLE_IOS_URL_SCHEME,
             appleSignIn: true,
             microsoftClientId: process.env.MICROSOFT_CLIENT_ID,
             microsoftTenant: process.env.MICROSOFT_TENANT,
@@ -105,7 +104,7 @@ Plugin options:
 | ---------------------------- | -------- | -------------------------------- |
 | `ios.googleClientId`         | iOS      | Google Sign-In on iOS.           |
 | `ios.googleServerClientId`   | iOS      | Google server auth code flow.    |
-| `ios.googleUrlScheme`        | iOS      | Google redirect URL scheme.      |
+| `ios.googleUrlScheme`        | iOS      | Optional Google redirect scheme. Derived from `ios.googleClientId` when omitted. |
 | `ios.appleSignIn`            | iOS      | Apple Sign-In entitlement.       |
 | `ios.microsoftClientId`      | iOS      | Microsoft Entra ID native login. |
 | `ios.microsoftTenant`        | iOS      | Microsoft tenant override.       |
@@ -114,6 +113,11 @@ Plugin options:
 | `android.microsoftClientId`  | Android  | Microsoft Entra ID native login. |
 | `android.microsoftTenant`    | Android  | Microsoft tenant override.       |
 | `android.microsoftB2cDomain` | Android  | Microsoft B2C hostname.          |
+
+When `ios.googleUrlScheme` is omitted, the plugin derives
+`com.googleusercontent.apps.<id>` from an iOS client ID that ends in
+`.apps.googleusercontent.com`. Set `ios.googleUrlScheme` only to override that
+value.
 
 Web reads provider client IDs from `expo.extra`; native platforms read values
 written by the plugin during prebuild.
@@ -178,7 +182,24 @@ export function SignInButton() {
 Imperative callers can use the same provider-aware options:
 
 ```ts
-import { AuthService } from "react-native-nitro-auth";
+import { AuthError, AuthService } from "react-native-nitro-auth";
+
+async function signInWithGoogle() {
+  try {
+    const user = await AuthService.loginAndGetUser("google", {
+      forceAccountPicker: true,
+    });
+    return user.idToken;
+  } catch (error) {
+    if (
+      error instanceof AuthError &&
+      (error.code === "cancelled" || error.code === "timeout")
+    ) {
+      return undefined;
+    }
+    throw error;
+  }
+}
 
 async function signInWithMicrosoft() {
   await AuthService.login("microsoft", {
@@ -187,6 +208,11 @@ async function signInWithMicrosoft() {
   });
 }
 ```
+
+`login()` still returns `Promise<void>` and leaves the session on
+`AuthService.currentUser`. `loginAndGetUser()` runs the same native login, then
+returns that user or rejects with `not_signed_in`. `logout()` is synchronous and
+returns `void`.
 
 ## Providers
 
@@ -207,6 +233,8 @@ Main exports:
 
 - `useAuth()` for reactive user, scope, loading, and error state.
 - `AuthService` for imperative operations and account listeners.
+- `AuthService.loginAndGetUser()` when the caller needs the signed-in user from
+  the same call.
 - `SocialButton` for provider-aware UI.
 - `AuthProvider` for `"google"`, `"apple"`, and `"microsoft"`.
 - `AuthError` and `AuthErrorCode` for deterministic failures.
@@ -245,8 +273,9 @@ Supported login options:
 
 ### Session operations
 
-- `logout()` clears package session state and signs out provider SDK state where
-  available. It does not revoke a provider grant or your backend session.
+- `logout()` is synchronous and returns `void`. It clears package session state
+  and signs out provider SDK state where available. It does not revoke a
+  provider grant or your backend session. Do not `await` it.
 - `silentRestore()` resolves with or without a restorable session. It never
   opens interactive UI: a near-expiry Google session rejects with
   `interaction_required` instead of showing a popup.

--- a/packages/react-native-nitro-auth/CHANGELOG.md
+++ b/packages/react-native-nitro-auth/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.8.0 - 2026-08-13
+
+### Breaking changes
+
+- None.
+
+### Added
+
+- `AuthService.loginAndGetUser()` runs the existing `login()` native call and
+  returns `currentUser`, or rejects with `not_signed_in` when login succeeds
+  without a session. `login()` remains `Promise<void>`.
+- The Expo plugin derives `ios.googleUrlScheme` from `ios.googleClientId` when
+  the scheme is omitted. An explicit `ios.googleUrlScheme` still wins.
+
+### Changed
+
+- Documented that `logout()` is synchronous `void`.
+
 ## 0.7.0 - 2026-08-12
 
 ### Breaking changes

--- a/packages/react-native-nitro-auth/README.md
+++ b/packages/react-native-nitro-auth/README.md
@@ -72,7 +72,6 @@ export default {
           ios: {
             googleClientId: process.env.GOOGLE_IOS_CLIENT_ID,
             googleServerClientId: process.env.GOOGLE_SERVER_CLIENT_ID,
-            googleUrlScheme: process.env.GOOGLE_IOS_URL_SCHEME,
             appleSignIn: true,
             microsoftClientId: process.env.MICROSOFT_CLIENT_ID,
             microsoftTenant: process.env.MICROSOFT_TENANT,
@@ -105,7 +104,7 @@ Plugin options:
 | ---------------------------- | -------- | -------------------------------- |
 | `ios.googleClientId`         | iOS      | Google Sign-In on iOS.           |
 | `ios.googleServerClientId`   | iOS      | Google server auth code flow.    |
-| `ios.googleUrlScheme`        | iOS      | Google redirect URL scheme.      |
+| `ios.googleUrlScheme`        | iOS      | Optional Google redirect scheme. Derived from `ios.googleClientId` when omitted. |
 | `ios.appleSignIn`            | iOS      | Apple Sign-In entitlement.       |
 | `ios.microsoftClientId`      | iOS      | Microsoft Entra ID native login. |
 | `ios.microsoftTenant`        | iOS      | Microsoft tenant override.       |
@@ -114,6 +113,11 @@ Plugin options:
 | `android.microsoftClientId`  | Android  | Microsoft Entra ID native login. |
 | `android.microsoftTenant`    | Android  | Microsoft tenant override.       |
 | `android.microsoftB2cDomain` | Android  | Microsoft B2C hostname.          |
+
+When `ios.googleUrlScheme` is omitted, the plugin derives
+`com.googleusercontent.apps.<id>` from an iOS client ID that ends in
+`.apps.googleusercontent.com`. Set `ios.googleUrlScheme` only to override that
+value.
 
 Web reads provider client IDs from `expo.extra`; native platforms read values
 written by the plugin during prebuild.
@@ -178,7 +182,24 @@ export function SignInButton() {
 Imperative callers can use the same provider-aware options:
 
 ```ts
-import { AuthService } from "react-native-nitro-auth";
+import { AuthError, AuthService } from "react-native-nitro-auth";
+
+async function signInWithGoogle() {
+  try {
+    const user = await AuthService.loginAndGetUser("google", {
+      forceAccountPicker: true,
+    });
+    return user.idToken;
+  } catch (error) {
+    if (
+      error instanceof AuthError &&
+      (error.code === "cancelled" || error.code === "timeout")
+    ) {
+      return undefined;
+    }
+    throw error;
+  }
+}
 
 async function signInWithMicrosoft() {
   await AuthService.login("microsoft", {
@@ -187,6 +208,11 @@ async function signInWithMicrosoft() {
   });
 }
 ```
+
+`login()` still returns `Promise<void>` and leaves the session on
+`AuthService.currentUser`. `loginAndGetUser()` runs the same native login, then
+returns that user or rejects with `not_signed_in`. `logout()` is synchronous and
+returns `void`.
 
 ## Providers
 
@@ -207,6 +233,8 @@ Main exports:
 
 - `useAuth()` for reactive user, scope, loading, and error state.
 - `AuthService` for imperative operations and account listeners.
+- `AuthService.loginAndGetUser()` when the caller needs the signed-in user from
+  the same call.
 - `SocialButton` for provider-aware UI.
 - `AuthProvider` for `"google"`, `"apple"`, and `"microsoft"`.
 - `AuthError` and `AuthErrorCode` for deterministic failures.
@@ -245,8 +273,9 @@ Supported login options:
 
 ### Session operations
 
-- `logout()` clears package session state and signs out provider SDK state where
-  available. It does not revoke a provider grant or your backend session.
+- `logout()` is synchronous and returns `void`. It clears package session state
+  and signs out provider SDK state where available. It does not revoke a
+  provider grant or your backend session. Do not `await` it.
 - `silentRestore()` resolves with or without a restorable session. It never
   opens interactive UI: a near-expiry Google session rejects with
   `interaction_required` instead of showing a popup.

--- a/packages/react-native-nitro-auth/app.plugin.js
+++ b/packages/react-native-nitro-auth/app.plugin.js
@@ -28,6 +28,33 @@ function getNitroAuthIosExtraPods(extraPods = []) {
   return pods;
 }
 
+const GOOGLE_IOS_CLIENT_ID_SUFFIX = ".apps.googleusercontent.com";
+
+function googleIosUrlSchemeFromClientId(clientId) {
+  if (typeof clientId !== "string") {
+    return undefined;
+  }
+  const trimmed = clientId.trim();
+  if (!trimmed.endsWith(GOOGLE_IOS_CLIENT_ID_SUFFIX)) {
+    return undefined;
+  }
+  const prefix = trimmed.slice(0, -GOOGLE_IOS_CLIENT_ID_SUFFIX.length);
+  if (!prefix) {
+    return undefined;
+  }
+  return `com.googleusercontent.apps.${prefix}`;
+}
+
+function resolveGoogleUrlScheme(ios = {}) {
+  if (typeof ios.googleUrlScheme === "string") {
+    const explicitScheme = ios.googleUrlScheme.trim();
+    if (explicitScheme) {
+      return explicitScheme;
+    }
+  }
+  return googleIosUrlSchemeFromClientId(ios.googleClientId);
+}
+
 const withNitroAuth = (config, props = {}) => {
   const { ios = {}, android = {} } = props;
 
@@ -44,17 +71,18 @@ const withNitroAuth = (config, props = {}) => {
     if (ios.googleServerClientId) {
       config.modResults.GIDServerClientID = ios.googleServerClientId;
     }
-    if (ios.googleUrlScheme) {
+    const googleUrlScheme = resolveGoogleUrlScheme(ios);
+    if (googleUrlScheme) {
       const existingSchemes = config.modResults.CFBundleURLTypes || [];
       if (
         !existingSchemes.some((scheme) =>
-          scheme.CFBundleURLSchemes.includes(ios.googleUrlScheme),
+          scheme.CFBundleURLSchemes.includes(googleUrlScheme),
         )
       ) {
         config.modResults.CFBundleURLTypes = [
           ...existingSchemes,
           {
-            CFBundleURLSchemes: [ios.googleUrlScheme],
+            CFBundleURLSchemes: [googleUrlScheme],
           },
         ];
       }
@@ -194,4 +222,6 @@ module.exports.withNitroAuth = withNitroAuth;
 module.exports._internal = {
   getNitroAuthIosExtraPods,
   googleSignInIosPods,
+  googleIosUrlSchemeFromClientId,
+  resolveGoogleUrlScheme,
 };

--- a/packages/react-native-nitro-auth/package.json
+++ b/packages/react-native-nitro-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-auth",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "High-performance authentication library for React Native with Google Sign-In, Apple Sign-In, and Microsoft Sign-In support, powered by Nitro Modules (JSI)",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/react-native-nitro-auth/src/__tests__/app-plugin.test.js
+++ b/packages/react-native-nitro-auth/src/__tests__/app-plugin.test.js
@@ -22,4 +22,40 @@ describe("Expo config plugin", () => {
       { name: "RecaptchaInterop", modular_headers: true },
     ]);
   });
+
+  it("derives the iOS Google URL scheme from a reversed client id", () => {
+    expect(
+      _internal.googleIosUrlSchemeFromClientId(
+        "123-abc.apps.googleusercontent.com",
+      ),
+    ).toBe("com.googleusercontent.apps.123-abc");
+  });
+
+  it("ignores client ids that are not reversed iOS Google ids", () => {
+    expect(
+      _internal.googleIosUrlSchemeFromClientId(
+        "123-abc.apps.googleusercontent.com.example",
+      ),
+    ).toBeUndefined();
+    expect(_internal.googleIosUrlSchemeFromClientId("")).toBeUndefined();
+    expect(_internal.googleIosUrlSchemeFromClientId(undefined)).toBeUndefined();
+  });
+
+  it("prefers an explicit googleUrlScheme over the derived value", () => {
+    expect(
+      _internal.resolveGoogleUrlScheme({
+        googleClientId: "123-abc.apps.googleusercontent.com",
+        googleUrlScheme: "com.googleusercontent.apps.custom",
+      }),
+    ).toBe("com.googleusercontent.apps.custom");
+  });
+
+  it("derives googleUrlScheme when the explicit override is blank", () => {
+    expect(
+      _internal.resolveGoogleUrlScheme({
+        googleClientId: "123-abc.apps.googleusercontent.com",
+        googleUrlScheme: "  ",
+      }),
+    ).toBe("com.googleusercontent.apps.123-abc");
+  });
 });

--- a/packages/react-native-nitro-auth/src/__tests__/provider-options.types.test.ts
+++ b/packages/react-native-nitro-auth/src/__tests__/provider-options.types.test.ts
@@ -1,5 +1,6 @@
 import type {
   AuthLogin,
+  AuthLoginAndGetUser,
   AppleIOSLoginOptions,
   AppleLoginOptions,
   AppleWebLoginOptions,
@@ -63,6 +64,9 @@ type WebServiceUsesTypedAuth = AssertTrue<
 type TypedAuthUsesProviderLogin = AssertTrue<
   IsAssignable<TypedAuth["login"], AuthLogin>
 >;
+type TypedAuthUsesLoginAndGetUser = AssertTrue<
+  IsAssignable<TypedAuth["loginAndGetUser"], AuthLoginAndGetUser>
+>;
 type HookUsesProviderLogin = AssertTrue<
   IsAssignable<UseAuthReturn["login"], AuthLogin>
 >;
@@ -120,6 +124,7 @@ void (0 as unknown as MicrosoftPromptValues);
 void (0 as unknown as NativeServiceUsesTypedAuth);
 void (0 as unknown as WebServiceUsesTypedAuth);
 void (0 as unknown as TypedAuthUsesProviderLogin);
+void (0 as unknown as TypedAuthUsesLoginAndGetUser);
 void (0 as unknown as HookUsesProviderLogin);
 void (0 as unknown as WebProviderOptionsMatchNative);
 void (0 as unknown as WebHookUsesProviderLogin);

--- a/packages/react-native-nitro-auth/src/__tests__/service.test.ts
+++ b/packages/react-native-nitro-auth/src/__tests__/service.test.ts
@@ -132,6 +132,7 @@ describe("AuthService", () => {
 
   it("should have all required methods", () => {
     expect(AuthService.login).toBeDefined();
+    expect(AuthService.loginAndGetUser).toBeDefined();
     expect(AuthService.logout).toBeDefined();
     expect(AuthService.requestScopes).toBeDefined();
     expect(AuthService.revokeScopes).toBeDefined();
@@ -166,6 +167,41 @@ describe("AuthService", () => {
       const error = await AuthService.login("google").catch((e: unknown) => e);
       expect(error).toBeInstanceOf(AuthError);
       expect((error as AuthError).code).toBe("network_error");
+    });
+
+    it("loginAndGetUser returns currentUser after login", async () => {
+      const user: AuthUser = {
+        provider: "google",
+        idToken: "id-token",
+      };
+      native().login.mockResolvedValueOnce(undefined);
+      mockCurrentUser = user;
+
+      await expect(AuthService.loginAndGetUser("google")).resolves.toEqual(
+        user,
+      );
+      expect(native().login).toHaveBeenCalledWith("google", undefined);
+    });
+
+    it("loginAndGetUser throws not_signed_in when login leaves currentUser empty", async () => {
+      native().login.mockResolvedValueOnce(undefined);
+      mockCurrentUser = undefined;
+
+      const error = await AuthService.loginAndGetUser("google").catch(
+        (e: unknown) => e,
+      );
+      expect(error).toBeInstanceOf(AuthError);
+      expect((error as AuthError).code).toBe("not_signed_in");
+      expect((error as AuthError).operation).toBe("login");
+    });
+
+    it("loginAndGetUser wraps native login errors in AuthError", async () => {
+      native().login.mockRejectedValueOnce(new Error("cancelled"));
+      const error = await AuthService.loginAndGetUser("google").catch(
+        (e: unknown) => e,
+      );
+      expect(error).toBeInstanceOf(AuthError);
+      expect((error as AuthError).code).toBe("cancelled");
     });
 
     it("requestScopes wraps native error in AuthError", async () => {

--- a/packages/react-native-nitro-auth/src/create-auth-service.ts
+++ b/packages/react-native-nitro-auth/src/create-auth-service.ts
@@ -76,6 +76,20 @@ export function createAuthService(
       );
     },
 
+    loginAndGetUser<Provider extends AuthProvider>(
+      provider: Provider,
+      options?: ProviderLoginOptions<Provider>,
+    ) {
+      return wrapAuthOperation("login", async () => {
+        await getAuth().login(provider, options);
+        const user = getAuth().currentUser;
+        if (!user) {
+          throw new AuthError("not_signed_in", "login");
+        }
+        return user;
+      });
+    },
+
     requestScopes(scopes: string[]) {
       return wrapAuthOperation("requestScopes", () =>
         getAuth().requestScopes(scopes),

--- a/packages/react-native-nitro-auth/src/provider-options.ts
+++ b/packages/react-native-nitro-auth/src/provider-options.ts
@@ -1,6 +1,7 @@
 import type {
   Auth,
   AuthProvider,
+  AuthUser,
   LoginOptions,
   ScopeRevocationResult,
 } from "./Auth.nitro";
@@ -56,7 +57,13 @@ export type AuthLogin = <Provider extends AuthProvider>(
   options?: ProviderLoginOptions<Provider>,
 ) => Promise<void>;
 
+export type AuthLoginAndGetUser = <Provider extends AuthProvider>(
+  provider: Provider,
+  options?: ProviderLoginOptions<Provider>,
+) => Promise<AuthUser>;
+
 export type TypedAuth = Omit<Auth, "login"> & {
   login: AuthLogin;
+  loginAndGetUser: AuthLoginAndGetUser;
   revokeScopesWithResult: (scopes: string[]) => Promise<ScopeRevocationResult>;
 };


### PR DESCRIPTION
# Summary

Add `loginAndGetUser()` and derive the iOS Google URL scheme from `ios.googleClientId` when omitted. Existing `login()` and explicit `ios.googleUrlScheme` stay unchanged.

# Changes

- Add `AuthService.loginAndGetUser()`: same native `login()`, then return `currentUser` or reject `not_signed_in`.
- Derive `com.googleusercontent.apps.<id>` from `ios.googleClientId` in the Expo plugin; an explicit `ios.googleUrlScheme` still wins.
- Document that `logout()` is synchronous `void`.
- Bump to 0.8.0. Breaking changes: none.