### PR TITLE
fix: preserve Auth social button callback typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Breaking changes are always listed first in each release section.
 - Unknown provider strings from platform callbacks now reject with
   `unsupported_provider` instead of defaulting to Apple (iOS silent restore,
   Android login callbacks).
+- `SocialButton.onError` preserves the 0.9.x `(error: AuthError) => void`
+  callback type; runtime failures are normalized to `AuthError` before the
+  callback.
 
 ## [0.9.0] - 2026-08-20
 
@@ -55,9 +58,7 @@ Breaking changes are always listed first in each release section.
 
 - Added a React Native 0.87.0 Strict TypeScript compatibility check while
   retaining React Native 0.86.2 for the package gate and Expo SDK 57 example.
-- `SocialButton` still delivers normalized `AuthError` instances at runtime;
-  the callback parameter remains `unknown` so existing callback annotations
-  stay source-compatible.
+- `SocialButtonProps.onError` now exposes the normalized `AuthError` contract.
 
 ## [0.8.0] - 2026-08-13
 

--- a/README.md
+++ b/README.md
@@ -305,9 +305,10 @@ Supported login options:
   `unsupported_provider`; local session state is unchanged.
 
 `SocialButton` normalizes runtime failures to `AuthError` instances. Its
-`onError` parameter remains typed as `unknown` for compatibility with earlier
-versions; use `error instanceof AuthError` before reading `code` or
-`underlyingMessage`.
+`onError` callback receives an `AuthError`, so TypeScript exposes `code`,
+`operation`, and `underlyingMessage` without a cast. Use
+`error instanceof AuthError` when handling an error value that came from
+outside the package.
 
 ### Token semantics and capabilities
 

--- a/packages/react-native-nitro-auth/CHANGELOG.md
+++ b/packages/react-native-nitro-auth/CHANGELOG.md
@@ -42,6 +42,9 @@ Breaking changes are always listed first in each release section.
 - Unknown provider strings from platform callbacks now reject with
   `unsupported_provider` instead of defaulting to Apple (iOS silent restore,
   Android login callbacks).
+- `SocialButton.onError` preserves the 0.9.x `(error: AuthError) => void`
+  callback type; runtime failures are normalized to `AuthError` before the
+  callback.
 
 ## [0.9.0] - 2026-08-20
 
@@ -55,9 +58,7 @@ Breaking changes are always listed first in each release section.
 
 - Added a React Native 0.87.0 Strict TypeScript compatibility check while
   retaining React Native 0.86.2 for the package gate and Expo SDK 57 example.
-- `SocialButton` still delivers normalized `AuthError` instances at runtime;
-  the callback parameter remains `unknown` so existing callback annotations
-  stay source-compatible.
+- `SocialButtonProps.onError` now exposes the normalized `AuthError` contract.
 
 ## [0.8.0] - 2026-08-13
 

--- a/packages/react-native-nitro-auth/README.md
+++ b/packages/react-native-nitro-auth/README.md
@@ -305,9 +305,10 @@ Supported login options:
   `unsupported_provider`; local session state is unchanged.
 
 `SocialButton` normalizes runtime failures to `AuthError` instances. Its
-`onError` parameter remains typed as `unknown` for compatibility with earlier
-versions; use `error instanceof AuthError` before reading `code` or
-`underlyingMessage`.
+`onError` callback receives an `AuthError`, so TypeScript exposes `code`,
+`operation`, and `underlyingMessage` without a cast. Use
+`error instanceof AuthError` when handling an error value that came from
+outside the package.
 
 ### Token semantics and capabilities
 

--- a/packages/react-native-nitro-auth/src/__tests__/provider-options.types.test.ts
+++ b/packages/react-native-nitro-auth/src/__tests__/provider-options.types.test.ts
@@ -1,6 +1,7 @@
 import type {
   AuthLogin,
   AuthLoginAndGetUser,
+  AuthError,
   AppleIOSLoginOptions,
   AppleLoginOptions,
   AppleWebLoginOptions,
@@ -79,16 +80,42 @@ type WebProviderOptionsMatchNative = AssertTrue<
 type WebHookUsesProviderLogin = AssertTrue<
   IsAssignable<WebUseAuthReturn["login"], AuthLogin>
 >;
+type SocialButtonErrorCallback = (error: AuthError) => void;
+type BroadSocialButtonErrorCallback = (error: unknown) => void;
 type NativeSocialButtonError = AssertTrue<
   IsAssignable<
     NonNullable<import("../index").SocialButtonProps["onError"]>,
-    (error: unknown) => void
+    SocialButtonErrorCallback
+  >
+>;
+type NativeSocialButtonAcceptsAuthError = AssertTrue<
+  IsAssignable<
+    SocialButtonErrorCallback,
+    NonNullable<import("../index").SocialButtonProps["onError"]>
+  >
+>;
+type NativeSocialButtonAcceptsBroadError = AssertTrue<
+  IsAssignable<
+    BroadSocialButtonErrorCallback,
+    NonNullable<import("../index").SocialButtonProps["onError"]>
   >
 >;
 type WebSocialButtonError = AssertTrue<
   IsAssignable<
     NonNullable<import("../index.web").SocialButtonProps["onError"]>,
-    (error: unknown) => void
+    SocialButtonErrorCallback
+  >
+>;
+type WebSocialButtonAcceptsAuthError = AssertTrue<
+  IsAssignable<
+    SocialButtonErrorCallback,
+    NonNullable<import("../index.web").SocialButtonProps["onError"]>
+  >
+>;
+type WebSocialButtonAcceptsBroadError = AssertTrue<
+  IsAssignable<
+    BroadSocialButtonErrorCallback,
+    NonNullable<import("../index.web").SocialButtonProps["onError"]>
   >
 >;
 
@@ -141,4 +168,8 @@ void (0 as unknown as HookUsesProviderLogin);
 void (0 as unknown as WebProviderOptionsMatchNative);
 void (0 as unknown as WebHookUsesProviderLogin);
 void (0 as unknown as NativeSocialButtonError);
+void (0 as unknown as NativeSocialButtonAcceptsAuthError);
+void (0 as unknown as NativeSocialButtonAcceptsBroadError);
 void (0 as unknown as WebSocialButtonError);
+void (0 as unknown as WebSocialButtonAcceptsAuthError);
+void (0 as unknown as WebSocialButtonAcceptsBroadError);

--- a/packages/react-native-nitro-auth/src/ui/social-button.tsx
+++ b/packages/react-native-nitro-auth/src/ui/social-button.tsx
@@ -24,11 +24,9 @@ export type SocialButtonProps = {
   disabled?: boolean;
   onSuccess?: (user: AuthUser) => void;
   /**
-   * Receives the normalized runtime error. Keep the parameter broad for
-   * source compatibility with earlier releases; narrow with AuthError when
-   * the callback needs provider-specific fields.
+   * Receives the normalized runtime error as an AuthError instance.
    */
-  onError?: (error: unknown) => void;
+  onError?: (error: AuthError) => void;
   onPress?: () => void;
 };
 

--- a/packages/react-native-nitro-auth/src/ui/social-button.web.tsx
+++ b/packages/react-native-nitro-auth/src/ui/social-button.web.tsx
@@ -23,11 +23,9 @@ export type SocialButtonProps = {
   disabled?: boolean;
   onSuccess?: (user: AuthUser) => void;
   /**
-   * Receives the normalized runtime error. Keep the parameter broad for
-   * source compatibility with earlier releases; narrow with AuthError when
-   * the callback needs provider-specific fields.
+   * Receives the normalized runtime error as an AuthError instance.
    */
-  onError?: (error: unknown) => void;
+  onError?: (error: AuthError) => void;
   onPress?: () => void;
 };
 


### PR DESCRIPTION
# Changes

- Restore `SocialButton.onError` to the `AuthError` parameter type shipped in 0.9.x, preserving strict TypeScript compatibility for existing callbacks.
- Keep runtime normalization to `AuthError` and document the callback contract consistently in both package README copies and the 0.10.0 CHANGELOG.
- Breaking changes: none; this follow-up removes the accidental callback-variance regression before publication.
