### PR TITLE
docs: finalize v0.10.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes are always listed first in each release section.
 
-## [0.10.0] - 2026-08-24
+## [0.10.0] - 2026-08-25
 
 ### Breaking changes
 
-- None.
+- None when upgrading from `0.9.x`. Direct upgrades from `0.8.x` or earlier
+  still require Nitro Modules `0.37.x` and a native rebuild as described in
+  the `0.9.0` entry.
 
 ### Fixed
 

--- a/packages/react-native-nitro-auth/CHANGELOG.md
+++ b/packages/react-native-nitro-auth/CHANGELOG.md
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes are always listed first in each release section.
 
-## [0.10.0] - 2026-08-24
+## [0.10.0] - 2026-08-25
 
 ### Breaking changes
 
-- None.
+- None when upgrading from `0.9.x`. Direct upgrades from `0.8.x` or earlier
+  still require Nitro Modules `0.37.x` and a native rebuild as described in
+  the `0.9.0` entry.
 
 ### Fixed
 


### PR DESCRIPTION
# Changes

- Finalize the 0.10.0 changelog with the publication date.
- Clarify the non-breaking 0.9.x upgrade path and the native rebuild requirement for older versions.